### PR TITLE
Two Fixes to Make Email Method More Robust

### DIFF
--- a/mfa/Common.py
+++ b/mfa/Common.py
@@ -2,7 +2,10 @@ from django.conf import settings
 from django.core.mail import EmailMessage
 
 def send(to,subject,body):
-    From = "%s <%s>" % (settings.EMAIL_FROM, settings.EMAIL_HOST_USER)
+    from_email_address = settings.EMAIL_HOST_USER
+    if '@' not in from_email_address:
+        from_email_address = settings.DEFAULT_FROM_EMAIL
+    From = "%s <%s>" % (settings.EMAIL_FROM, from_email_address)
     email = EmailMessage(subject,body,From,to)
     email.content_subtype = "html"
     return email.send(False)

--- a/mfa/Email.py
+++ b/mfa/Email.py
@@ -14,9 +14,7 @@ def sendEmail(request,username,secret):
     kwargs = {key: username}
     user = User.objects.get(**kwargs)
     res=render(request,"mfa_email_token_template.html",{"request":request,"user":user,'otp':secret})
-    body = str(res.content).replace("b'", "")
-    body = body[:-1] if body.endswith("'") else body
-    return  send([user.email],"OTP", body)
+    return send([user.email],"OTP", res.content.decode())
 
 @never_cache
 def start(request):

--- a/mfa/Email.py
+++ b/mfa/Email.py
@@ -14,7 +14,9 @@ def sendEmail(request,username,secret):
     kwargs = {key: username}
     user = User.objects.get(**kwargs)
     res=render(request,"mfa_email_token_template.html",{"request":request,"user":user,'otp':secret})
-    return  send([user.email],"OTP", str(res.content))
+    body = str(res.content).replace("b'", "")
+    body = body[:-1] if body.endswith("'") else body
+    return  send([user.email],"OTP", body)
 
 @never_cache
 def start(request):


### PR DESCRIPTION
- Removes embedded bytestring syntax from email message body.
```
 "b'Hello user, here's your code: 81244'" -> "Hello user, here's your code: 81244"
```

- Use DEFAULT_FROM_EMAIL instead of EMAIL_HOST_USER for the from email address if EMAIL_HOST_USER does not have an "@" sign in it.

    - Some email relay services require a username that is not an email address for the EMAIL_HOST_USER (e.g.: https://sendgrid.com/docs/API_Reference/SMTP_API/integrating_with_the_smtp_api.html)