### PR TITLE
Andreas dickow patch postgresql support device register

### DIFF
--- a/mfa/TrustedDevice.py
+++ b/mfa/TrustedDevice.py
@@ -62,7 +62,7 @@ def add(request):
         key=request.POST["key"].replace("-","").replace(" ","").upper()
         context["username"] = request.POST["username"]
         context["key"] = request.POST["key"]
-        trusted_keys=User_Keys.objects.filter(username=request.POST["username"],properties__has="$.key="+key)
+        trusted_keys=User_Keys.objects.filter(username=request.POST["username"],properties__iregex=rf'{key}')
         cookie=False
         if trusted_keys.exists():
             tk=trusted_keys[0]

--- a/mfa/U2F.py
+++ b/mfa/U2F.py
@@ -52,7 +52,7 @@ def validate(request,username):
     challenge = request.session.pop('_u2f_challenge_')
     device, c, t = complete_authentication(challenge, data, [settings.U2F_APPID])
 
-    key=User_Keys.objects.get(username=username,properties__shas="$.device.publicKey=%s"%device["publicKey"])
+    key = User_Keys.objects.filter(username=username, properties__iregex=rf'{device["publicKey"]}')
     key.last_used=timezone.now()
     key.save()
     mfa = {"verified": True, "method": "U2F","id":key.id}

--- a/mfa/U2F.py
+++ b/mfa/U2F.py
@@ -52,7 +52,7 @@ def validate(request,username):
     challenge = request.session.pop('_u2f_challenge_')
     device, c, t = complete_authentication(challenge, data, [settings.U2F_APPID])
 
-    key = User_Keys.objects.filter(username=username, properties__iregex=rf'{device["publicKey"]}')
+    key = User_Keys.objects.get(username=username, properties__iregex=rf'{device["publicKey"]}')
     key.last_used=timezone.now()
     key.save()
     mfa = {"verified": True, "method": "U2F","id":key.id}


### PR DESCRIPTION
Occurerd on Django3.2b1 on Python 3.9 and Postgresql DB Backend, properties__has and properties__shas function translates to a raw SQL call WHERE (JSON_EXTRACT...
the JSON_EXTRACT function is Mysql specific and should not occur in this place, I propose using iregex instead.

Root cause is the underlying library jsonLookup used within the project, which currently only supports mysql