### PR TITLE
Fix missing import of get_redirect_url in totp and U2F

### DIFF
--- a/mfa/U2F.py
+++ b/mfa/U2F.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.http import HttpResponse
 from .models import *
 from .views import login
+from .Common import get_redirect_url
 import datetime
 from django.utils import timezone
 

--- a/mfa/totp.py
+++ b/mfa/totp.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 from django.http import HttpResponse
+from .Common import get_redirect_url
 from .models import *
 from django.template.context_processors import csrf
 import simplejson


### PR DESCRIPTION
In the current version the implementation of TOTP and U2F is not working because of an undefined method get_redirect_url in the start method. The import already is done correctly in the FIDO2 implementation. So I added it to TOTP and U2F.

