### PR TITLE
use block.super for more friendly overriding of parent blocks

### DIFF
--- a/mfa/templates/MFA.html
+++ b/mfa/templates/MFA.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 {% block head %}
+{{block.super}}
     <script type="text/javascript">
     function confirmDel(id) {
         $.ajax({
@@ -39,6 +40,7 @@
     <script src="{% static 'mfa/js/bootstrap-toggle.min.js'%}"></script>
 {% endblock %}
 {% block content %}
+{{block.super}}
     <br/>
     <br/>
     <div class="container">


### PR DESCRIPTION
My `mfa_auth_base.html` file inherited from another base template file that already used blocks "head" and "content", which was causing problems. The django-mfa wasn't calling `{{block.super}}` so all the base template's content wasn't getting rendered. This seems to have fixed that or me.