### PR TITLE
django-ssl has been renamed?

### DIFF
--- a/example/requiremnts.txt
+++ b/example/requiremnts.txt
@@ -1,2 +1,2 @@
 django >= 2.2
-django_ssl
+django-sslserver


### PR DESCRIPTION
When trying to install the django-ssl module from [requirements.txt](https://github.com/mkalioby/django-mfa2/blob/master/example/requiremnts.txt#L2), you'll get an error message. 
I was able to get the django application started by changed to this module, I think they simply renamed it?
[github.com/teddziuba/django-sslserver]([https://github.com/teddziuba/django-sslserver])

I couldn't get FIDO2 Auth working yet...