### PR TITLE
Add 400 error status to exception handling in mfa/FIDO2.complete_reg

### DIFF
--- a/mfa/FIDO2.py
+++ b/mfa/FIDO2.py
@@ -47,10 +47,13 @@ def begin_registeration(request):
 
 @csrf_exempt
 def complete_reg(request):
-    """Completes the registeration, called by API"""
+    """Completes the registration, called by API"""
     try:
         if not "fido_state" in request.session:
-            return JsonResponse({'status': 'ERR', "message": "FIDO Status can't be found, please try again"})
+            return JsonResponse(
+                {'status': 'ERR', "message": "FIDO Status can't be found, please try again"},
+                status=400
+            )
         data = cbor.decode(request.body)
 
         client_data = CollectedClientData(data['clientDataJSON'])
@@ -81,7 +84,7 @@ def complete_reg(request):
             client.captureException()
         except:
             pass
-        return JsonResponse({'status': 'ERR', "message": "Error on server, please try again later"})
+        return JsonResponse({'status': 'ERR', "message": "Error on server, please try again later"}, status=400)
 
 
 def start(request):


### PR DESCRIPTION
Proof of concept, for testing purpose I added some random bytes to request body to check if exception handling is returning properly 400 status code
and then for the same reason I removes fido_state from request.session dict to test if the first exception handling returning 400 status code. 


![Screenshot from 2024-01-23 13-39-11](https://github.com/mkalioby/django-mfa2/assets/18052257/1b593bc4-d3b9-4f03-aada-a6f1a9993726)
![Screenshot from 2024-01-23 13-38-55](https://github.com/mkalioby/django-mfa2/assets/18052257/d0d07260-b785-4afa-820e-6db4ff8ed4ec)
![Screenshot from 2024-01-23 13-15-30](https://github.com/mkalioby/django-mfa2/assets/18052257/f86612a9-ee13-4f2b-84cb-f729f9c0dcd1)
![Screenshot from 2024-01-23 13-15-10](https://github.com/mkalioby/django-mfa2/assets/18052257/5d289270-878f-4ac6-a5af-539ecf0276ac)
