### PR TITLE
Userkey enabled

### DIFF
--- a/mfa/TrustedDevice.py
+++ b/mfa/TrustedDevice.py
@@ -1,6 +1,7 @@
 import string
 import random
 from datetime import datetime, timedelta
+from django.conf import settings
 from django.shortcuts import render
 from django.http import HttpResponse
 from django.template.context_processors import csrf

--- a/mfa/totp.py
+++ b/mfa/totp.py
@@ -15,7 +15,11 @@ from .models import User_Keys
 
 
 def verify_login(request, username, token):
-    for key in User_Keys.objects.filter(username=username, key_type="TOTP"):
+    for key in User_Keys.objects.filter(
+        username=username,
+        key_type="TOTP",
+        enabled=True,
+    ):
         totp = pyotp.TOTP(key.properties["secret_key"])
         if totp.verify(token, valid_window=30):
             key.last_used = timezone.now()


### PR DESCRIPTION
The reason for adding 'enabled=True' is that elsewhere in the code it seems to be appropriate and when verifying a login it is probably most appropriate. I may not have got that right if there is a deeper reason for ignoring 'enabled'. Another thought is the User_Keys model has 'enabled' as a Boolean but throughout the code, other queries use 'enabled=1' as a query argument. Django must permit this as otherwise the software wouldn't work. For consistency, it might be better to use 'enabled=1' but True is more explicit.