### PR TITLE
Defensively cope with missing POST field

### DIFF
--- a/mfa/Email.py
+++ b/mfa/Email.py
@@ -20,7 +20,7 @@ def sendEmail(request, username, secret):
     user = User.objects.get(**kwargs)
     res = render(
         request,
-        "mfa_email_token_template.html",
+        "Email/mfa_email_token_template.html",
         {"request": request, "user": user, "otp": secret},
     )
     subject = getattr(settings, "MFA_OTP_EMAIL_SUBJECT", "OTP")
@@ -37,7 +37,8 @@ def start(request):
     """Start adding email as a 2nd factor"""
     context = csrf(request)
     if request.method == "POST":
-        if request.session["email_secret"] == request.POST["otp"]:  # if successful
+        otp = request.POST.get("otp", "").strip()
+        if request.session["email_secret"] == otp:  # if successful
             uk = User_Keys()
             User, USERNAME_FIELD = get_username_field()
             uk.username = USERNAME_FIELD
@@ -85,7 +86,8 @@ def auth(request):
     if request.method == "POST":
         username = request.session["base_username"]
 
-        if request.session["email_secret"] == request.POST["otp"].strip():
+        otp = request.POST.get("otp", "").strip()
+        if request.session["email_secret"] == otp:
             email_keys = User_Keys.objects.filter(username=username, key_type="Email")
             if email_keys.exists():
                 uk = email_keys.first()

--- a/mfa/templates/Email/mfa_email_token_template.html
+++ b/mfa/templates/Email/mfa_email_token_template.html
@@ -4,7 +4,7 @@
         <title>MFA Email token</title>
     </head>
     <body>
-        Dear {{ username }},<br/>
+        Dear {{ user.get_username }},<br/>
         Your OTP is: <b>{{ otp }}</b>
 
         Thanks


### PR DESCRIPTION
The first change in this PR prefixes the mfa_email_token_template.html with 'Email/'. That fixes a missing template.
The next two are identical defensive programming changes (not fixes) necessary because the upcoming tests try to exercise the software with bad input.
Finally, the template itself looks for username but that is not in the context. Instead 'user' is handed in so this change is to make the template display 'user.get_username'. Another option would have been to pass in username instead of user.