### PR TITLE
Added decode to convert bytes returned by recheck to str

### DIFF
--- a/mfa/helpers.py
+++ b/mfa/helpers.py
@@ -31,10 +31,10 @@ def recheck(request):
         return JsonResponse({"res": TrustedDevice.verify(request)})
 
     elif method == "U2F":
-        return JsonResponse({"html": U2F.recheck(request).content})
+        return JsonResponse({"html": U2F.recheck(request).content.decode()})
 
     elif method == "FIDO2":
-        return JsonResponse({"html": FIDO2.recheck(request).content})
+        return JsonResponse({"html": FIDO2.recheck(request).content.decode()})
 
     elif method == "TOTP":
-        return JsonResponse({"html": totp.recheck(request).content})
+        return JsonResponse({"html": totp.recheck(request).content.decode()})


### PR DESCRIPTION
This might be wrong but as near as I can tell the three recheck functions return Django HTTPResponse objects which need their "bytestring" content to be decoded to string. In Django 5.2 we can get HTTPResponse.text which is a string (default utf-8). If this change is wrong and should not be merged I can delete the relevant tests before doing that PR.