### PR TITLE
Four changes plus template adjustments

### DIFF
--- a/mfa/TrustedDevice.py
+++ b/mfa/TrustedDevice.py
@@ -1,6 +1,7 @@
 import string
 import random
 from datetime import datetime, timedelta
+from django.conf import settings
 from django.shortcuts import render
 from django.http import HttpResponse
 from django.template.context_processors import csrf
@@ -126,7 +127,7 @@ def start(request):
             "url": request.scheme
             + "://"
             + request.get_host()
-            + reverse("add_trusted_device"),
+            + reverse("add_td"),
         }
     except:
         del request.session["td_id"]
@@ -135,7 +136,7 @@ def start(request):
 
 
 def send_email(request):
-    body = render(request, "TrustedDevices/email.html", {}).content
+    body = render(request, "TrustedDevices/email.html", {}).content.decode()
     from .Common import send
 
     e = request.user.email
@@ -158,7 +159,7 @@ def verify(request):
         if json["username"].lower() == request.session["base_username"].lower():
             try:
                 uk = User_Keys.objects.get(
-                    username=request.POST["username"].lower(),
+                    username=json["username"].lower(),
                     properties__icontains='"key": "%s"' % json["key"],
                 )
                 if uk.enabled and uk.properties["status"] == "trusted":

--- a/mfa/templates/TrustedDevices/email.html
+++ b/mfa/templates/TrustedDevices/email.html
@@ -1,4 +1,4 @@
-<p>Dear {{ request.user.last_name }}, {{ request.user.first_name }}</p>
+<p>Dear {{ user.get_full_name }}</p>
 <p>You requested the link to add a new trusted device, please follow the link below<br/>
-<a href="{{ HOST }}{% url 'mfa_add_new_trusted_device' %}">{{ HOST }}{% url 'mfa_add_new_trusted_device' %}</a>
+<a href="{{ HOST }}{% url 'add_td' %}">{{ HOST }}{% url 'add_td' %}</a>
 </p>

--- a/mfa/templates/mfa_auth_base.html
+++ b/mfa/templates/mfa_auth_base.html
@@ -1,0 +1,7 @@
+{% extends 'mfa_base.html' %}
+{% block head %}
+    {{ block.super }}
+{% endblock %}
+{% block content %}
+    {{ block.super }}
+{% endblock %}


### PR DESCRIPTION
Fixed missing import settings from django.conf

Changed to reverse("add_td") instead of reverse("add_trusted_device") for consistency elsewhere

Append .decode() to change bytes to string for Django email

Adjusted templates/TrustedDevices/email.html url name from 'mfa_add_new_trusted_device' (which name/view does not exist) to 'add_td' (which does exist). Obviously this could be done the other way so this and the second change above is the minimal fix and may not suit intentions.

Added mfa_auth_base.html to templates as a named 'extends' template in all other templates. 

Adjusted line 161 username=request.POST["username"] to username=json["username"] because json["username"] is correctly derived from request.session["base_username"] whereas the username data is not necessarily available from request.POST
